### PR TITLE
Update submodule paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,24 @@
 [submodule "pearai-app"]
-	path = pearai-app
-	url = https://github.com/trypear/pearai-app.git
+	path = heliod-app
+	url = https://github.com/heliod/pearai-app.git
 [submodule "pearai-submodule"]
-	path = pearai-submodule
-	url = https://github.com/trypear/pearai-submodule.git
+	path = heliod-submodule
+	url = https://github.com/heliod/pearai-submodule.git
 [submodule "pear-landing-page"]
 	path = pear-landing-page
-	url = https://github.com/trypear/pear-landing-page.git
+	url = https://github.com/heliod/pear-landing-page.git
 [submodule "pearai-documentation"]
-	path = pearai-documentation
-	url = https://github.com/trypear/pearai-documentation.git
+	path = heliod-documentation
+	url = https://github.com/heliod/pearai-documentation.git
 [submodule "pearai-server-issues-public"]
-	path = pearai-server-issues-public
-	url = https://github.com/trypear/pearai-server-issues-public.git
+	path = heliod-server-issues-public
+	url = https://github.com/heliod/pearai-server-issues-public.git
 [submodule "pearai-server"]
-	path = pearai-server
-	url = https://github.com/trypear/pearai-server.git
+	path = heliod-server
+	url = https://github.com/heliod/pearai-server.git
 [submodule "pearai-mcp"]
-	path = pearai-mcp
-	url = https://github.com/trypear/pearai-mcp
+	path = heliod-mcp
+	url = https://github.com/heliod/pearai-mcp
 [submodule "PearAI-Roo-Code"]
-	path = PearAI-Roo-Code
-	url = https://github.com/trypear/PearAI-Roo-Code
+	path = heliod-Roo-Code
+	url = https://github.com/heliod/PearAI-Roo-Code


### PR DESCRIPTION
## Summary
- update `.gitmodules` to use `heliod-*` paths
- switch URLs to the Heliod organization

## Testing
- `git submodule sync`

------
https://chatgpt.com/codex/tasks/task_e_68479e8dbe648326be1e6adb592e9c6a