### PR TITLE
Update Heliod submodule paths

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -19,14 +19,14 @@ jobs:
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'
 
-          # Initialize and update all submodules except pearai-server
-          git submodule update --init --recursive -- pear-landing-page pearai-app pearai-documentation pearai-server-issues-public pearai-submodule
+          # Initialize and update all submodules except heliod-server
+          git submodule update --init --recursive -- heliod-landing-page heliod-app heliod-documentation heliod-server-issues-public heliod-submodule
 
       - name: Update submodules
         run: |
           # Selective submodule update
           git submodule foreach '
-              if [ "$path" != "pearai-server" ]; then
+              if [ "$path" != "heliod-server" ]; then
                   git fetch
                   git checkout origin/main
               else


### PR DESCRIPTION
## Summary
- update the submodule initialization list for the new Heliod repo names
- adjust the exclusion check to skip `heliod-server`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68479e93c6548326b4e519757a894c56