### PR TITLE
Update Heliod branding

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "🧩 Launch PearAI Extension Host",
+      "name": "🧩 Launch Heliod Extension Host",
       "type": "extensionHost",
       "request": "launch",
       "args": [
@@ -17,7 +17,7 @@
       "killBehavior": "polite"
     },
     {
-      "name": "📱 Attach to PearAI App",
+      "name": "📱 Attach to Heliod App",
       "type": "node",
       "request": "attach",
       "port": 9229,
@@ -30,7 +30,7 @@
       "killBehavior": "polite"
     },
     {
-      "name": "🚀 Attach to PearAI-Roo-Code",
+      "name": "🚀 Attach to Heliod Roo Code",
       "type": "node",
       "request": "attach",
       "port": 9230,
@@ -61,7 +61,7 @@
       "killBehavior": "polite"
     },
     {
-      "name": "📱 Run PearAI App Watch",
+      "name": "📱 Run Heliod App Watch",
       "type": "node-terminal",
       "request": "launch",
       "command": "npm run watch",
@@ -104,7 +104,7 @@
         "🧩 Run Submodule GUI Dev",
         "🧩 Run Submodule Extension Watch",
         "🧩 Run Submodule TSC Watch",
-        "📱 Run PearAI App Watch",
+        "📱 Run Heliod App Watch",
         "🚀 Run Roo Code Watch",
         "🚀 Run Roo Code Dev"
       ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,9 +1,9 @@
 {
   "version": "2.0.0",
   "tasks": [
-    // PEARAI APP TASKS
+    // HELIOD APP TASKS
     {
-      "label": "📱 PearAI App: Watch",
+      "label": "📱 Heliod App: Watch",
       "type": "shell",
       "command": "cd ${workspaceFolder}/pearai-app && yarn watch",
       "problemMatcher": ["$tsc-watch"],
@@ -13,10 +13,10 @@
         "panel": "new",
         "group": "dev"
       },
-      "detail": "Run PearAI App in watch mode"
+      "detail": "Run Heliod App in watch mode"
     },
     {
-      "label": "📱 PearAI App: Install Dependencies",
+      "label": "📱 Heliod App: Install Dependencies",
       "type": "shell",
       "command": "cd ${workspaceFolder}/pearai-app && ./scripts/pearai/install-dependencies.sh",
       "problemMatcher": [],
@@ -25,10 +25,10 @@
         "panel": "new",
         "group": "setup"
       },
-      "detail": "Install dependencies for PearAI App"
+      "detail": "Install dependencies for Heliod App"
     },
 
-    // PEARAI SUBMODULE TASKS
+    // HELIOD SUBMODULE TASKS
     {
       "label": "🧩 Submodule: Install and Build",
       "type": "shell",
@@ -39,7 +39,7 @@
         "panel": "new",
         "group": "setup"
       },
-      "detail": "Install and build PearAI Submodule"
+      "detail": "Install and build Heliod Submodule"
     },
     {
       "label": "🧩 Submodule: ESBuild Watch",
@@ -81,7 +81,7 @@
       "detail": "Run Vite dev server for GUI component"
     },
 
-    // PEARAI ROO CODE TASKS
+    // HELIOD ROO CODE TASKS
     {
       "label": "🚀 Roo Code: Watch",
       "type": "shell",
@@ -93,7 +93,7 @@
         "panel": "new",
         "group": "dev"
       },
-      "detail": "Run PearAI Roo Code in watch mode"
+      "detail": "Run Heliod Roo Code in watch mode"
     },
     {
       "label": "🚀 Roo Code: Dev",
@@ -106,7 +106,7 @@
         "panel": "new",
         "group": "dev"
       },
-      "detail": "Run PearAI Roo Code dev server"
+      "detail": "Run Heliod Roo Code dev server"
     },
     {
       "label": "🚀 Roo Code: Install All",
@@ -118,7 +118,7 @@
         "panel": "new",
         "group": "setup"
       },
-      "detail": "Install all dependencies for PearAI Roo Code"
+      "detail": "Install all dependencies for Heliod Roo Code"
     },
 
     // UTILITY TASKS
@@ -139,7 +139,7 @@
     {
       "label": "🚀 Start All Dev Servers",
       "dependsOn": [
-        "📱 PearAI App: Watch",
+        "📱 Heliod App: Watch",
         "🧩 Submodule: ESBuild Watch",
         "🧩 Submodule: TSC Watch",
         "🧩 Submodule: GUI Dev",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Repository Guidelines for Codex Agents
 
-This repository aggregates several PearAI submodules. Only a few shell scripts
+This repository aggregates several Heliod submodules. Only a few shell scripts
 and configuration files live at the root. The submodule directories are empty by
 default and should not be edited in Codex PRs.
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# PearAI Master Repository
+# Heliod Master Repository
 
-PearAI aims to be an inventory that curates the leading, cutting-edge AI tools in one place. Our unified interface seamlessly integrates these solutions, allowing users to effortlessly switch between tools without needing to waste effort hunting for alternatives.
+Heliod aims to be an inventory that curates the leading, cutting-edge AI tools in one place. Our unified interface seamlessly integrates these solutions, allowing users to effortlessly switch between tools without needing to waste effort hunting for alternatives.
 
-What you're seeing here is the conglomeration of all the repositories that make up the entire PearAI project. This is only the beginning, and the list shall keep expanding. For details, visit each repository individually:
+What you're seeing here is the conglomeration of all the repositories that make up the entire Heliod project. This is only the beginning, and the list shall keep expanding. For details, visit each repository individually:
 
-- [pearai-app](https://github.com/trypear/pearai-app): this is the VSCode fork part of PearAI and the outer directory of the project. It contains the bulk of the editor functionalities.
-- [pearai-submodule](https://github.com/trypear/pearai-submodule): this is the Continue fork part of PearAI and is a submodule of `pearai-app`. It contains the bulk of the AI chat functionalities.
-- [pear-landing-page](https://github.com/trypear/pear-landing-page): this is the landing page of PearAI.
-- [pearai-documentation](https://github.com/trypear/pearai-documentation): this is the [documentation page](https://trypear.ai/docs) of PearAI and is linked to from the landing page.
-- [pearai-server](https://github.com/trypear/pearai-server): this is the server of PearAI which is semi-private to maintain security. The use of PearAI server is optional, and serves as a way to provide convenience for users who do not wish to use their own API keys.
-- [pearai-server-issues-public](https://github.com/trypear/pearai-server-issues-public): this is where all the issues are listed for the PearAI server.
+- [pearai-app](https://github.com/trypear/pearai-app): this is the VSCode fork part of Heliod and the outer directory of the project. It contains the bulk of the editor functionalities.
+- [pearai-submodule](https://github.com/trypear/pearai-submodule): this is the Continue fork part of Heliod and is a submodule of `pearai-app`. It contains the bulk of the AI chat functionalities.
+- [pear-landing-page](https://github.com/trypear/pear-landing-page): this is the landing page of Heliod.
+- [pearai-documentation](https://github.com/trypear/pearai-documentation): this is the [documentation page](https://heliod.ai/docs) of Heliod and is linked to from the landing page.
+- [pearai-server](https://github.com/trypear/pearai-server): this is the server of Heliod which is semi-private to maintain security. The use of Heliod server is optional, and serves as a way to provide convenience for users who do not wish to use their own API keys.
+- [pearai-server-issues-public](https://github.com/trypear/pearai-server-issues-public): this is where all the issues are listed for the Heliod server.
 
 ## Contributing
 
-We welcome contributions from the community! Whether you're fixing a bug, improving the documentation, or adding a new feature, we appreciate your help in making PearAI better. There is a lot of context involved and we understand it can be overwhelming when first trying to join the project. Here is a quick summary of key information and how we currently work together:
+We welcome contributions from the community! Whether you're fixing a bug, improving the documentation, or adding a new feature, we appreciate your help in making Heliod better. There is a lot of context involved and we understand it can be overwhelming when first trying to join the project. Here is a quick summary of key information and how we currently work together:
 
 - We have a bunch of issues which are free to tackle (see the issues tab on individual repos). Make sure to leave a comment indicating you're working on it (check for existing comments also). You can raise a PR anytime and we usually review them pretty quickly.
-- If you notice anything about Pear that you think you could improve, then let us know!
+- If you notice anything about Heliod that you think you could improve, then let us know!
 - We have a lot on our plate so it's easy for us to miss something. The best way to get our attention is to ping us directly in our Discord server.
 
 > [!IMPORTANT]
@@ -43,19 +43,19 @@ Ensure you have the following tools installed:
 
 ## Installation
 
-To get started with PearAI development, you'll need to clone this repo (pearai-master) and install the dependencies for each component:
+To get started with Heliod development, you'll need to clone this repo (heliosai-master) and install the dependencies for each component:
 
-1. PearAI App:
+1. Heliod App:
 ```bash
 cd ./pearai-app && npm i
 ```
 
-2. PearAI Roo Code:
+2. Heliod Roo Code:
 ```bash
 cd ./pearai-roo-code && npm run install:all
 ```
 
-3. PearAI Submodule:
+3. Heliod Submodule:
 ```bash
 ./pearai-submodule/install-and-build.sh  # For Unix/Mac
 ./pearai-submodule/install-and-build.ps1 # For Windows
@@ -68,10 +68,10 @@ To start development:
 ![image](https://github.com/user-attachments/assets/2f823fef-03c6-4d0e-8966-75ff7fa0f9d8)
 
 1. Launch the development servers:
-   - In PearAI (or vscode), go to Run and Debug
+   - In Heliod (or vscode), go to Run and Debug
    - Select and run the "🚀 Start All Dev Servers" task
 
-2. Start the PearAI instance:
+2. Start the Heliod instance:
 ```bash
 ./pearai-app/scripts/code.sh  # For Unix/Mac
 ./pearai-app/scripts/code.ps1 # For Windows
@@ -83,15 +83,15 @@ To start development:
 
 ## Technology Stack
 
-- PearAI is in TypeScript/Electron.js
-- PearAI landing page is Next.js/React with Supabase auth (TailwindCSS + Shadcn)
-- PearAI backend is a Python FastAPI server with Supabase database
+- Heliod is in TypeScript/Electron.js
+- Heliod landing page is Next.js/React with Supabase auth (TailwindCSS + Shadcn)
+- Heliod backend is a Python FastAPI server with Supabase database
 - Logging/Telemetry is done with Axiom and PostHog
 
 ## Contact
 
-For any questions or issues, feel free to open an issue, or you can also reach out to us directly in the [PearAI Discord](https://discord.gg/7QMraJUsQt), or email us at [team@trypear.ai](mailto:team@trypear.ai).
+For any questions or issues, feel free to open an issue, or you can also reach out to us directly in the [Heliod Discord](https://discord.gg/heliod), or email us at [team@heliod.ai](mailto:team@heliod.ai).
 
 ## FAQ
 
-Checkout our [FAQ](https://trypear.ai/faq) on the website.
+Checkout our [FAQ](https://heliod.ai/faq) on the website.

--- a/setup-app-dev.sh
+++ b/setup-app-dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # setup-app-dev.sh
-# Master script to install all dependencies for PearAI app, submodule, and Roo code
+# Master script to install all dependencies for Heliod app, submodule, and Roo code
 # This script runs all necessary installation commands in sequence
 
 set -e  # Exit immediately if a command exits with a non-zero status
@@ -26,20 +26,20 @@ cd "$ROOT_DIR/PearAI-Roo-Code" || handle_error "Could not navigate to PearAI-Roo
 npm run install:all || handle_error "Failed to install PearAI-Roo-Code dependencies"
 print_message "PearAI-Roo-Code dependencies installed successfully!"
 
-# Step 2: Install and build PearAI submodule
-print_message "Installing and building PearAI submodule..."
+# Step 2: Install and build Heliod submodule
+print_message "Installing and building Heliod submodule..."
 cd "$ROOT_DIR/pearai-submodule" || handle_error "Could not navigate to pearai-submodule directory"
-./install-and-build.sh || handle_error "Failed to install and build PearAI submodule"
-print_message "PearAI submodule installed and built successfully!"
+./install-and-build.sh || handle_error "Failed to install and build Heliod submodule"
+print_message "Heliod submodule installed and built successfully!"
 
-# Step 3: Install PearAI app dependencies
-print_message "Installing PearAI app dependencies..."
+# Step 3: Install Heliod app dependencies
+print_message "Installing Heliod app dependencies..."
 cd "$ROOT_DIR/pearai-app" || handle_error "Could not navigate to pearai-app directory"
-npm install || handle_error "Failed to install PearAI app dependencies"
-print_message "PearAI app dependencies installed successfully!"
+npm install || handle_error "Failed to install Heliod app dependencies"
+print_message "Heliod app dependencies installed successfully!"
 
 # Return to root directory
 cd "$ROOT_DIR" || handle_error "Could not navigate back to root directory"
 
 print_message "All installations completed successfully! 🎉"
-echo "The PearAI app, submodule, and Roo code are now set up and ready for development."
+echo "The Heliod app, submodule, and Roo code are now set up and ready for development."


### PR DESCRIPTION
## Summary
- rename PearAI references to Heliod across docs and scripts
- update Discord link and contact email

## Testing
- `bash -n setup-app-dev.sh`
- `jq . .vscode/launch.json`
- `jq . .vscode/tasks.json` *(fails: Invalid numeric literal)*


------
https://chatgpt.com/codex/tasks/task_e_68479eb7e41083269d846be3835f2952